### PR TITLE
Annonces des MiDiro

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,9 @@ theme: aediroum
 # Menu
 menu:
   main:
+    - Name: Événements
+      Identifier: evenements
+      Weight: 4
     - Name: Documents
       Identifier: documents
       Weight: 5

--- a/content/midiros/_index.md
+++ b/content/midiros/_index.md
@@ -1,0 +1,10 @@
+---
+title: Conférences MiDiro
+menu:
+  main:
+    parent: evenements
+    weight: 2
+sitemap:
+  changefreq: daily
+  priority: 0.7
+---

--- a/content/midiros/_index.md
+++ b/content/midiros/_index.md
@@ -8,3 +8,7 @@ sitemap:
   changefreq: daily
   priority: 0.7
 ---
+
+Les MiDiro sont des conférences organisées par l’association et portant sur des sujets variés en informatique.
+Ces conférences incluent aussi bien des présentations de *sujets de recherche* par les professeurs et les étudiants gradués que des exposés en *lien avec l’industrie* par des intervenants extérieurs.
+Elles s’adressent à toutes les étudiantes et tous les étudiants en informatique du département, et en particulier celles et ceux au premier cycle.

--- a/content/midiros/bioinformatique-arn.md
+++ b/content/midiros/bioinformatique-arn.md
@@ -1,0 +1,28 @@
+---
+date: 2013-11-22T11:30:00-05:00
+title: "La bioinformatique de l'ARN"
+speaker: Paul Dallaire
+room: AA-1175
+draft: false
+---
+
+Je ferai un survol de la bioinformatique telle que je la voie :
+Qu'est-ce ?
+D'où cela vient-il et où cela va-t'il ?
+Est-ce cool et important ?
+
+Après une présentation des entités manipulées par la bioinformatique, je trancherai grossièrement dans ce jeune corpus pour identifier ses points d'ancrage (l'information, l'algorithmique et la modélisation).
+
+<!--more-->
+
+Nous nous attarderons surtout à la modélisation des ARN.
+Les découvertes de la dernière décennie (et demi) à ce sujet sont fascinantes.
+Contrairement à ce qu'on pouvait croire, ces molécules sont en fait très nombreuses et impliquées directement dans le contrôle de l'expression génétique.
+
+Aussi, grâce à de nouvelles méthodes de mesure, on a découvert à quel point leurs structures 3D changent dynamiquement avec des effets très tangibles sur des maladies diverses (SIDA, autisme, etc).
+
+Le Laboratoire d'Ingénierie des ARN dont les bureaux sont à l'IRIC et dirigé par François Major (fondateur du LBIT) est à la fine pointe en ce domaine.
+On y trouve un laboratoire d'informatique rempli de passionnés d'informatique (sec) et un laboratoire de biologie moléculaire (mouillé).
+
+Je survolerai les recherches effectuées au laboratoire dont la prédiction de structure 3D par retour en arrière (backtrack) et la modélisation du contrôle génétique grâce à l'algorithme des mariages stables.
+Et, s'il reste de la pizza, j'aborderai mes travaux sur la dynamique des ARN grâce entre autre à la programmation dynamique.

--- a/content/midiros/calcul-securitaire.md
+++ b/content/midiros/calcul-securitaire.md
@@ -1,0 +1,14 @@
+---
+date: 2013-04-19T12:30:00-05:00
+title: "Calcul sécuritaire"
+speaker: Samuel Ranellucci (Étudiant au Doctoract, DIRO)
+room: AA-3195
+draft: false
+---
+
+Le Calcul Sécuritaire est le domaine qui étudie comment apprendre le résultat d'une fonction publique sur des inputs privés sans l'utilisation de tiers parti honnête.
+Les applications du calcul sécuritaire incluent le vote, l'enchère et la transmission de message anonyme.
+
+Dans cette présentation, nous allons voir les définitions de base et de protocoles simples de ce domaine.
+
+<!--more-->

--- a/content/midiros/compilation-volee.md
+++ b/content/midiros/compilation-volee.md
@@ -1,0 +1,14 @@
+---
+date: 2014-02-07T11:30:00-05:00
+title: "Stratégies adaptatives de compilation à la volée"
+speaker: Maxime Chevalier-Boisvert (DIRO)
+room: AA-1175
+draft: false
+---
+
+Un avantage majeur des compilateurs à la volée par rapport aux compilateurs statiques est leur habileté à s'adapter aux paramètres d'un programme en cours d'exécution.
+Ceci est particulièrement important quand on travaille avec un langage de programmation dynamique tel que JavaScript ou [Python](https://python.org).
+
+Nous introduirons des stratégies de compilation adaptives qui visent à atteindre deux objectifs a priori conflictuels : générer du code machine plus optimisé tout en réduisant le temps de compilation. 
+
+<!--more-->

--- a/content/midiros/entreprise-apres-etudes.md
+++ b/content/midiros/entreprise-apres-etudes.md
@@ -1,0 +1,15 @@
+---
+date: 2014-01-17T11:30:00-05:00
+title: "Dois-je démarrer mon entreprise après mes études ? Bonne question !"
+speaker: Alain Lavoie (IROSOFT)
+room: AA-1175
+draft: false
+---
+
+Alain Lavoie, président et cofondateur de la compagnie Irosoft, présentera son cheminement professionnel.
+Il discutera des bienfaits de démarrer une compagnie.
+Il vous dira que le métier d’entrepreneur est accessible à tous pourvu que la passion y soit.
+
+L’objectif de la présentation est de vous démontrer que le métier d’informaticien est le plus beau métier du monde et qu’il nous permet d’atteindre les plus hauts sommets, si on le désire...
+
+<!--more-->

--- a/content/midiros/expansion-requete.md
+++ b/content/midiros/expansion-requete.md
@@ -1,0 +1,15 @@
+---
+date: 2015-02-06T11:30:00-05:00
+title: "Expansion de requête diversifiée"
+speaker: Arbi Bouchoucha
+room: AA-1177
+draft: false
+---
+
+Je présenterai brièvement le domaine de recherche d’information à la base de moteurs de recherche "à la Google" afin de situer mon sujet de thèse.
+
+Contrairement aux approches existantes qui diversifient les résultats de recherche afin de couvrir toutes les interprétations de la requête, j’ai exploré une nouvelle approche basée sur la diversification de la requête.
+
+Afin de garantir une bonne couverture des différentes intentions de l'utilisateur derrière sa requête, les termes d’expansion sont sélectionnés à partir de plusieurs ressources, comme les logs de requêtes, [Wikipédia](https://wikipedia.org), [ConceptNet](//conceptnet5.media.mit.edu) et les documents de feedback.
+
+<!--more-->

--- a/content/midiros/machines-boltzmann-restreintes.md
+++ b/content/midiros/machines-boltzmann-restreintes.md
@@ -1,0 +1,16 @@
+---
+date: 2014-04-11T11:30:00-05:00
+title: "Des ordinateurs qui rêvent : introduction aux machines de Boltzmann restreintes"
+speaker: Vincent Dumoulin (DIRO)
+room: AA-1175
+draft: false
+---
+
+L'apprentissage automatique est une branche de l'intelligence artificielle qui génère beaucoup d'engouement de nos jours.
+
+Plutôt que d'inculquer aux ordinateurs des comportements intelligents de façon explicite, l'apprentissage automatique s'intéresse à leur laisser découvrir leurs propres règles par l'exemple.
+Cette approche permet entre autres de développer des modèles qui ont la propriété surprenante d'imaginer des exemples plausibles mais jamais vus auparavant.
+
+Dans cette conférence, je propose de lever le voile sur un de ces modèles, appelé machine de Boltzmann restreinte (RBM), et d'explorer son fonctionnement et ses applications. 
+
+<!--more-->

--- a/content/midiros/maillage-remaillage.md
+++ b/content/midiros/maillage-remaillage.md
@@ -1,0 +1,15 @@
+---
+date: 2014-02-28T11:30:00-05:00
+title: "La géométrie derrière l'infographie : Maillage et remaillage"
+speaker: Gilles-Philippe Paillé (DIRO)
+room: AA-1175
+draft: false
+---
+
+Des millions de triangles sont présents dans chaque image d'un film d'animation 3D, et pourtant vous n'en voyez aucun.
+Vous ferez un saut dans l'arrière-scène de l'infographie où les maillages sont omniprésents et où quelques triangles peuvent former un sujet de doctorat.
+
+Je présenterai une notion de qualité d'un maillage et les techniques de remaillage visant à améliorer cette qualité.
+Je présenterai également l'importance des maillages dans des domaines connexes, tels que l'architecture et l'ingénierie, afin d'illustrer le fait que tout objet peut être, et souvent même doit être maillé. 
+
+<!--more-->

--- a/content/midiros/meteovis.md
+++ b/content/midiros/meteovis.md
@@ -1,0 +1,17 @@
+---
+date: 2013-11-01T11:30:00-05:00
+title: "MétéoVis : un système de présentation personnalisé d'informations environnementales"
+speaker: Mohamed Mouine (étudiant au doctorat, DIRO)
+room: AA-1175
+draft: false
+---
+
+Dans le contexte de la présentation d’une grande masse d’information, le système doit sélectionner les informations pertinentes selon l’utilisateur.
+
+MétéoVis est un générateur sur demande de visualisations de bulletins climatiques combinant du texte et des graphiques.
+Pour cela nous profilons l’utilisateur pour dégager ses besoins et ses préférences.
+Nous utilisons pour cette tâche le clustering pour dégager des cas similaires.
+
+Notre thèse développe des méthodes pour automatiser l’exploration d’informations de type environnemental, pour prévoir les préférences et les besoins des utilisateurs et pour générer des bulletins météorologiques personnalisés. 
+
+<!--more-->

--- a/content/midiros/optimisation-reseaux-transport.md
+++ b/content/midiros/optimisation-reseaux-transport.md
@@ -1,0 +1,13 @@
+---
+date: 2013-03-22T12:30:00-05:00
+title: "Ménagez vos transports! L'optimisation des réseaux par l'informatique et la RO"
+speaker: Bernard Gendron (Professeur titulaire, DIRO; Directeur, CIRRELT)
+room: AA-1175
+draft: false
+---
+
+Je ferai un tour d'horizon de plusieurs applications en transports modélisées et résolues grâce à un champ de recherche passionnant : l'optimisation de réseaux, une belle combinaison d'informatique, de RO et de mathématiques.
+
+Des plus courts chemins aux tournées de véhicules, en passant par les problèmes classiques d'équilibre de trafic et du voyageur de commerce, je présenterai plusieurs problèmes d'optimisation de réseaux, toujours en référence à des problèmes "réels" en transports !
+
+<!--more-->

--- a/content/midiros/reseaux-vehiculaires-securite.md
+++ b/content/midiros/reseaux-vehiculaires-securite.md
@@ -1,0 +1,17 @@
+---
+date: 2014-03-21T11:30:00-05:00
+title: "Les réseaux véhiculaires et leurs applications de sécurité : Comment améliorer la sécurité routière en exploitant les communications sans fil"
+speaker: Nader Chaabouni (DIRO)
+room: AA-1175
+draft: false
+---
+
+Les accidents de routes se produisent tous les jours partout dans le monde résultant chaque année à plus de 100 milliards de dollars de dégâts et plus que 50 millions de victimes dont au moins 1 million de morts.
+Une grande partie de ces accidents pourront être évités si les conducteurs sont prévenus du danger quelques secondes en avance.
+
+Dans cette perspective, la communauté scientifique s'est intéressée à l'exploitation des technologies de communication (notamment sans fil) pour émettre des notifications préventives pour aviser les conducteurs des dangers potentiels dans la route.
+
+Cette présentation focalise sur les applications possibles des réseaux véhiculaires pour la sécurité active sur les routes.
+Je vais aussi présenter certains défis et problèmes à résoudre pour ce type de réseau qui sont en relation avec mes travaux de recherche. 
+
+<!--more-->

--- a/content/midiros/simulations-fluides.md
+++ b/content/midiros/simulations-fluides.md
@@ -1,0 +1,14 @@
+---
+date: 2015-02-27T11:30:00-05:00
+title: "Contrôle et augmentation de détails pour les simulations de fluides"
+speaker: Olivier Mercier
+room: AA-1177
+draft: false
+---
+
+Les simulations de fluides tels que l'eau et la fumée sont de nos jours chose courante dans les films et les jeux vidéos.
+
+Dans cet exposé, je présenterai les fondements des algorithmes utilisés pour générer de telles simulations.
+Je discuterai ensuite de diverses techniques qui permettent de contrôler le comportement des fluides et permettent de diverger de leur comportement naturel, ce qui permet par exemple de simuler des personnages composés d'eau, ou de former du texte avec de la fumée.
+
+<!--more-->

--- a/content/midiros/vision-cinema-immersif.md
+++ b/content/midiros/vision-cinema-immersif.md
@@ -1,0 +1,16 @@
+---
+date: 2013-12-06T11:30:00-05:00
+title: "La vision par ordinateur appliquée au cinéma immersif"
+speaker: Vincent Chapdelaine-Couture (DIRO)
+room: AA-1207
+draft: false
+---
+
+Le cinéma 360 3D projette sur des écrans immersifs des vidéos qui fournissent de l'information sur la profondeur de la scène tout autour des spectateurs.
+Ce type de cinéma comporte des défis liés notamment au tournage de vidéos 360 3D de scènes dynamiques et à la projection sur des écrans courbes très réfléchissants.
+
+Nous tentons de relever ces défis par la vision par ordinateur, c'est-à-dire par l'analyse automatique d'images prises par des caméras.
+Par exemple, nous avons développé deux méthodes de production de vidéos 360 3D, une par l'assemblage de milliers d'images prises par 2 caméras en rotation sur un trépied, et une par l'utilisation de 3 caméras munies de lentilles très grand angle.
+Nous utilisons aussi une caméra pour aligner automatiquement plusieurs projecteurs de façon à créer une projection continue sur n'importe quelle forme d'écran.
+
+<!--more-->

--- a/content/midiros/visualisation-logiciel.md
+++ b/content/midiros/visualisation-logiciel.md
@@ -1,0 +1,20 @@
+---
+date: 2013-02-15T12:30:00-05:00
+title: "La visualisation du logiciel ou comment voir et explorer l'intangible"
+speaker: Houari Sahraoui (Professeur titulaire, DIRO)
+room: AA-3195
+draft: false
+---
+
+Les logiciels font partie de notre vie de tous les jours et sont de plus en plus grands et complexes (plusieurs centaines de milliers de lignes de code).
+Ils sont appelés à être modifiés fréquemment pour satisfaire les besoins changeants des utilisateurs et doivent constamment s’adapter à l’évolution de leur environnement.
+
+<!--more-->
+
+Pour permettre de garder ces logiciels à jour et maintenir la qualité de leurs services, les spécialistes en maintenance doivent comprendre rapidement quelle partie du code source doit être modifiée et prévenir les effets de ces modifications sur les autres parties du logiciel.
+La visualisation du logiciel est un outil efficace et flexible pour effectuer ce type de tâches de maintenance qui sont difficiles à automatiser.
+Elle permet l’exploration et l'analyse de grands ensembles de données sur les logiciels à différents niveaux de détail et avec des perspectives multiples.
+Cependant, l’efficacité des environnements de visualisation dépend de leur adéquation avec les tâches de maintenance qu’ils sont censés supporter.
+
+Dans cet exposé, nous présentons les principes et les lignes directrices pour développer des outils de visualisation de logiciels en considérant explicitement la nature des données et des actions mises en oeuvre dans les tâches de maintenance.
+Ces principes sont illustrés à travers l’environnement de visualisation VERSO.

--- a/themes/aediroum/layouts/section/midiros.html
+++ b/themes/aediroum/layouts/section/midiros.html
@@ -1,6 +1,15 @@
 {{ define "main" }}
   <h3>{{ .Title }}</h3>
 
+  {{ .Content }}
+
+  {{ with .OutputFormats.Get "rss" -}}
+  <p>
+    Ci-dessous les conférences à venir et les conférences passées.
+    <a href="{{ .Permalink }}">Suivez le flux RSS</a> pour être informé des prochaines conférences.
+  </p>
+  {{ end -}}
+
   {{ $page := .Paginator 5 }}
 
   <ul class="list-unstyled">


### PR DESCRIPTION
Je propose de restaurer la catégorie «MiDiro» sur le site. Cette catégorie sera mise à jour avec les annonces de conférences MiDiro à venir. Les gens pourront utiliser le flux RSS (généré automatiquement par Hugo) pour en être informés.

Ce PR restaure les annonces de MiDiro des années 2013–2015 depuis [un ancien commit](https://github.com/AEDIROUM/aediroum.iro.umontreal.ca/tree/2026d5ac42116686e5402f76d6c4bebe49460368). La page `/midiros` (accessible depuis le menu «Évenements») liste les dernières annonces de conférences, j’y ai ajouté une description du concept des MiDiro. 