### PR TITLE
Annonce du MiDiro 2022-10-13

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,4 +26,5 @@ disableHugoGeneratorInject: true
 
 # Miscellaneous
 metaDataFormat: yaml
+buildFuture: true
 paginate: 5

--- a/content/midiros/reseaux-tenseurs.md
+++ b/content/midiros/reseaux-tenseurs.md
@@ -1,0 +1,11 @@
+---
+date: 2022-10-13T12:30:00-04:00
+title: "Tenseurs et réseaux de tenseurs en apprentissage automatique"
+speaker: Guillaume Rabusseau (professeur adjoint, DIRO)
+room: AA-3195
+draft: false
+---
+
+Dans cette présentation, je commencerai par introduire les tenseurs (une généralisation des vecteurs et des matrices) ainsi que les réseaux de tenseurs (un langage graphique à la fois intuitif et rigoureux pour décrire des opérations complexes entre tenseurs). Je discuterai ensuite des défis associés aux données tensorielles et des différentes méthodes permettant de représenter et de manipuler efficacement ce type de données. Enfin, je présenterai plus en particulier des applications de ces méthodes dans le cadre de l'apprentissage automatique.
+
+<!--more-->


### PR DESCRIPTION
J’ai réglé le paramètre `buildFuture` de Hugo à `true` pour qu’il inclue l’article du prochain MiDiro, dont la date est dans le futur.